### PR TITLE
Update client.yml

### DIFF
--- a/files/configuration/dnscollector/client.yml
+++ b/files/configuration/dnscollector/client.yml
@@ -35,7 +35,7 @@ multiplexer:
         flush-interval: 10
         tls-support: false
         tls-insecure: false
-        server-id: "SERVER_ID" @
+        server-id: "SERVER_ID"
         buffer-size: 100
         chan-buffer-size: 65535
 


### PR DESCRIPTION
This character triggers an error

```
config error: error parsing YAML file: yaml: line 38: found character that cannot start any token
```