### PR TITLE
Introduce SSL Parameter Configuration

### DIFF
--- a/files/configuration/pdnssoccli/pdnssoccli.yml
+++ b/files/configuration/pdnssoccli/pdnssoccli.yml
@@ -3,6 +3,7 @@ logging_level: "INFO"
 misp_servers:
   - domain: "https://example-misp-instance.com"
     api_key: "API_KEY"
+    verify_ssl: True
     # misp.search() arguments
     args:
       enforce_warninglist: True

--- a/files/docker/pdnssoccli.yml
+++ b/files/docker/pdnssoccli.yml
@@ -3,7 +3,7 @@ logging_level: "INFO"
 misp_servers:
   - domain: "https://example-misp-instance.com"
     api_key: "API_KEY"
-    verify_ssl: false
+    verify_ssl: False
     # misp.search() arguments
     args:
       enforce_warninglist: True

--- a/files/docker/pdnssoccli.yml
+++ b/files/docker/pdnssoccli.yml
@@ -3,6 +3,7 @@ logging_level: "INFO"
 misp_servers:
   - domain: "https://example-misp-instance.com"
     api_key: "API_KEY"
+    verify_ssl: false
     # misp.search() arguments
     args:
       enforce_warninglist: True


### PR DESCRIPTION
Implemented an SSL parameter configuration feature, allowing users to specify SSL settings in the pdnssoccli.yml configuration file. This enhancement enables the use of self-signed certificates without SSL verification failures. Users can configure the SSL parameter accordingly to accommodate various SSL certificate setups, ensuring seamless integration with different environments.